### PR TITLE
fix(security): prevent script injection via branch name in tag-on-merge

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -29,8 +29,9 @@ jobs:
 
       - name: Determine Version Increment Type
         id: determine
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           INCREMENT_TYPE="patch"
 
           case "$BRANCH_NAME" in


### PR DESCRIPTION
## Summary

- Mueve `BRANCH_NAME` del interpolado inline `${{ github.event.pull_request.head.ref }}` directamente en el script bash al bloque `env:` del step.
- Elimina el vector de inyección CWE-78: un nombre de rama malicioso ya no puede romper el contexto bash y ejecutar comandos arbitrarios.
- Sigue el mismo patrón ya aplicado correctamente para `PR_TITLE` en el step `Tag and Push release`.

## Cambio

**Antes (vulnerable):**
```yaml
run: |
  BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
```

**Después (seguro):**
```yaml
env:
  BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
run: |
```

## Test plan

- [ ] Verificar que PRs con nombres de rama normales (`feature-x`, `bugfix-y`) siguen determinando correctamente el tipo de incremento.
- [ ] Verificar que un nombre de rama con caracteres especiales (`feature-x"; echo pwned; echo "`) no rompe el workflow.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)