### PR TITLE
fix(bump-version): validate semver format before arithmetic to prevent silent wrong versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /composer.lock
 .idea
 .phpunit.result.cache
+.claude
+skills-lock.json

--- a/etc/git/scripts/bump-version.sh
+++ b/etc/git/scripts/bump-version.sh
@@ -13,6 +13,7 @@ calculate_next_version() {
 
     local current_version_no_v=$(echo "$latest_tag" | sed 's/^v//')
 
+    local major minor patch
     IFS='.' read -r major minor patch <<< "$current_version_no_v"
 
     if ! [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ && "$patch" =~ ^[0-9]+$ ]]; then

--- a/etc/git/scripts/bump-version.sh
+++ b/etc/git/scripts/bump-version.sh
@@ -15,6 +15,11 @@ calculate_next_version() {
 
     IFS='.' read -r major minor patch <<< "$current_version_no_v"
 
+    if ! [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ && "$patch" =~ ^[0-9]+$ ]]; then
+        echo "Error: tag '$latest_tag' no tiene formato semver válido (X.Y.Z)" >&2
+        return 1
+    fi
+
     case "$increment_type" in
         major)
             major=$((major + 1))

--- a/etc/git/scripts/bump-version.sh
+++ b/etc/git/scripts/bump-version.sh
@@ -17,7 +17,7 @@ calculate_next_version() {
     IFS='.' read -r major minor patch <<< "$current_version_no_v"
 
     if ! [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ && "$patch" =~ ^[0-9]+$ ]]; then
-        echo "Error: tag '$latest_tag' no tiene formato semver válido (X.Y.Z)" >&2
+        echo "Error: latest tag '$latest_tag' is not a valid semver X.Y.Z (numeric only, no pre-release or build metadata)" >&2
         return 1
     fi
 


### PR DESCRIPTION
## Summary

- Añade validación de formato `X.Y.Z` tras el parsing de `IFS='.' read` en `bump-version.sh`.
- Si alguno de los tres componentes no es numérico entero (ej. `0-rc1` de un tag como `v1.0.0-rc1`, o vacío de `v1.0`), el script emite un mensaje de error en stderr y retorna código 1 en lugar de producir silenciosamente una versión incorrecta.
- El workflow en GitHub Actions falla rápido y visible en lugar de publicar un tag equivocado.

## Casos cubiertos

| Tag | Antes | Después |
|-----|-------|---------|
| `v1.2.3` (válido) | `1.2.4` ✓ | `1.2.4` ✓ |
| `v1.0.0-rc1` | `1.0.1` (silencioso) | Error + exit 1 ✓ |
| `v1.0` (dos componentes) | `1.0.1` (silencioso) | Error + exit 1 ✓ |

## Test plan

- [ ] Verificar que un tag semver normal (`v1.2.3`) sigue produciendo la versión correcta para `patch`, `minor` y `major`.
- [ ] Verificar que un tag con sufijo pre-release falla con mensaje claro en stderr.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)